### PR TITLE
Fix zero-decimal currency 100x overcharge

### DIFF
--- a/includes/class-fluentcart-integration.php
+++ b/includes/class-fluentcart-integration.php
@@ -103,7 +103,9 @@ class FluentCartIntegration
             );
         }
 
-        $priceInCents = round($amount * 100);
+        $currencySettings = \FluentCart\Api\CurrencySettings::get();
+        $isZeroDecimal = ! empty($currencySettings['is_zero_decimal']);
+        $priceInCents = $isZeroDecimal ? round($amount) : round($amount * 100);
 
         $productTitle = apply_filters('fcnyp_product_title', $productTitle);
 
@@ -171,6 +173,10 @@ class FluentCartIntegration
      */
     private static function formatPrice($amount)
     {
-        return \FluentCart\Api\CurrencySettings::getFormattedPrice(round($amount * 100));
+        $settings = \FluentCart\Api\CurrencySettings::get();
+        $isZeroDecimal = ! empty($settings['is_zero_decimal']);
+        $cents = $isZeroDecimal ? round($amount) : round($amount * 100);
+
+        return \FluentCart\Api\CurrencySettings::getFormattedPrice($cents);
     }
 }


### PR DESCRIPTION
## What this fixes

Closes #20 (regression of #1 and #8).

If your store runs JPY, KRW, VND, or any other zero-decimal currency — every single transaction through this plugin gets overcharged by 100x. A visitor enters ¥50, FluentCart charges ¥5,000. That's not a rounding quirk, that's a "your customers are losing real money" bug.

## Where it breaks

Two places, same root cause:

**`validateCustomItem()` line 106:**
```php
$priceInCents = round($amount * 100);
```

**`formatPrice()` line 174:**
```php
return \FluentCart\Api\CurrencySettings::getFormattedPrice(round($amount * 100));
```

Both unconditionally multiply by 100, assuming every currency has cents. JPY doesn't. KRW doesn't. FluentCart stores zero-decimal prices as whole units, not cents — so the `* 100` creates a phantom conversion that inflates the price.

The irony is, the *frontend* already handles this correctly. The form reads `data-is-zero-decimal="true"` and adjusts the input step to `1`, the placeholder to `0`. The server just didn't get the memo.

## What I changed

Two conditionals. That's it.

```php
$currencySettings = \FluentCart\Api\CurrencySettings::get();
$isZeroDecimal = ! empty($currencySettings['is_zero_decimal']);
$priceInCents = $isZeroDecimal ? round($amount) : round($amount * 100);
```

Same pattern in `formatPrice()`. If `is_zero_decimal` is true, pass the amount through as-is. Otherwise, multiply by 100 as before. Standard currencies (USD, EUR, GBP) are completely unaffected.

## How I tested it

1. Switched the FluentCart store to JPY
2. Added a form with `[fc_name_your_price min="1" max="100"]`
3. Entered ¥50, clicked Pay
4. **Before**: Checkout showed ¥5,000 (100x overcharge)
5. **After**: Checkout shows ¥50 (correct)
6. Switched back to PLN — still works normally at 25.00zł

I also verified that `CurrencySettings::get()` returns the `is_zero_decimal` flag correctly for both JPY (true) and PLN (false).