### PR TITLE
Add loading state to submit button

### DIFF
--- a/assets/css/pricing-form.css
+++ b/assets/css/pricing-form.css
@@ -163,6 +163,12 @@
     opacity: 0.85;
 }
 
+.fcnyp-form__button--loading {
+    opacity: 0.7;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
 /* Error
    ========================================================================== */
 

--- a/assets/js/pricing-form.js
+++ b/assets/js/pricing-form.js
@@ -241,6 +241,10 @@
         _fcnyp_sig: this.config.signature,
       });
 
+      this.els.button.disabled = true;
+      this.els.button.classList.add('fcnyp-form__button--loading');
+      this.els.button.textContent = (window.fcnypI18n && window.fcnypI18n.processing) || 'Processing\u2026';
+
       window.location.href = this.config.checkoutUrl + '?' + params.toString();
     }
 

--- a/includes/class-shortcode.php
+++ b/includes/class-shortcode.php
@@ -131,8 +131,9 @@ class Shortcode
         wp_enqueue_style('fcnyp-form', FCNYP_PLUGIN_URL . 'assets/css/pricing-form.css', [], FCNYP_VERSION);
         wp_enqueue_script('fcnyp-form', FCNYP_PLUGIN_URL . 'assets/js/pricing-form.js', [], FCNYP_VERSION, true);
         wp_localize_script('fcnyp-form', 'fcnypI18n', [
-            'errorMin' => __('Please enter an amount of at least {amount}', 'fc-name-your-price'),
-            'errorMax' => __('Maximum amount is {amount}', 'fc-name-your-price'),
+            'errorMin'    => __('Please enter an amount of at least {amount}', 'fc-name-your-price'),
+            'errorMax'    => __('Maximum amount is {amount}', 'fc-name-your-price'),
+            'processing'  => __('Processing…', 'fc-name-your-price'),
         ]);
     }
 


### PR DESCRIPTION
## What this fixes

Closes #21 (regression of #5).

Click the Pay button. Nothing happens visually. The button stays the same colour, same text, same cursor. If you're on anything slower than a fibre connection — or the server takes an extra second to respond — you're going to click it again. And maybe a third time for good measure.

Each click fires `onSubmit()`, builds a new checkout URL, and sets `window.location.href`. No guard. No debounce. No visual feedback. Three clicks = three checkout items.

## What I changed

Three lines of JS, five lines of CSS, and one translatable string.

**In `pricing-form.js` — right before the redirect:**
```js
this.els.button.disabled = true;
this.els.button.classList.add('fcnyp-form__button--loading');
this.els.button.textContent = (window.fcnypI18n && window.fcnypI18n.processing) || 'Processing…';
```

**In `pricing-form.css`:**
```css
.fcnyp-form__button--loading {
    opacity: 0.7;
    cursor: not-allowed;
    pointer-events: none;
}
```

**In `class-shortcode.php` — added to the i18n object:**
```php
'processing' => __('Processing…', 'fc-name-your-price'),
```

The `disabled` attribute prevents the form from submitting again. The CSS class adds visual feedback. The text swap tells the visitor something is happening. The string is translatable through the existing `fcnypI18n` mechanism, so it'll work with the `.pot` file like the error messages do.

## How I tested it

1. Added a form: `[fc_name_your_price min="5" max="500" preset_amounts="10,25,50"]`
2. Selected 25zł, clicked Pay
3. **Before**: Button stayed at "Pay 25.00zł", `disabled: false`, no class change
4. **After**: Button immediately shows "Processing…", `disabled: true`, opacity drops to 0.7, cursor changes to `not-allowed`
5. Rapid double-click — only one checkout item created

Every payment form on the internet does this. Now this one does too.