### PR TITLE
Add actual validation to validatePaymentItem()

### DIFF
--- a/includes/class-fluentcart-integration.php
+++ b/includes/class-fluentcart-integration.php
@@ -160,6 +160,16 @@ class FluentCartIntegration
             return $items;
         }
 
+        $price = $variation->price ?? 0;
+        if ($price <= 0) {
+            return [null, null];
+        }
+
+        $title = $variation->post_title ?? ($variation->title ?? '');
+        if (empty($title)) {
+            return [null, null];
+        }
+
         return [$product, $variation];
     }
 


### PR DESCRIPTION
## What this fixes

Closes #22 (regression of #7).

`validatePaymentItem()` currently identifies FCNYP items and then returns them completely unchanged. Both code paths — "this is ours" and "this isn't ours" — do the exact same thing. The method exists purely to give the impression that payment-stage validation is happening.

```php
// Current code — spot the difference (there isn't one)
if (strpos((string) $itemId, 'fcnyp_') !== 0) {
    return $items;       // not ours → pass through
}
return [$product, $variation];  // ours → also pass through
```

## Why it matters

The `fluent_cart/payment/validate_custom_item` filter runs during **payment processing**, not just initial checkout. That means payment retries after failed card attempts, subscription renewals, and any re-processing of the order.

Your `validateCustomItem()` does proper HMAC + nonce verification at checkout time — and it's good work, genuinely well done. But `validatePaymentItem()` is supposed to be the second line of defence when the payment actually gets charged. Right now there is no second line. It's like putting a steel front door on your house and leaving the back door wide open.

## What I changed

Added basic sanity checks for the stored variation data:

```php
// Reject items with non-positive prices
$price = $variation->price ?? 0;
if ($price <= 0) {
    return [null, null];
}

// Reject items with empty titles
$title = $variation->post_title ?? ($variation->title ?? '');
if (empty($title)) {
    return [null, null];
}
```

These are deliberately minimal — I'm not trying to re-validate the entire HMAC chain at payment time (that data isn't available at this stage). Just catching the obvious cases: if an item somehow ended up with a zero/negative price or an empty title, it shouldn't process.

Returning `[null, null]` tells FluentCart to reject the item, which is the documented pattern for this filter.

## How I tested it

Code audit — this filter fires during payment processing which can't be easily triggered from a browser test. The logic is straightforward: two null checks on data that should always be present for valid FCNYP items.