### PR TITLE
Replace Date.now() with crypto.randomUUID() for item IDs

### DIFF
--- a/assets/js/pricing-form.js
+++ b/assets/js/pricing-form.js
@@ -226,7 +226,7 @@
 
       var params = new URLSearchParams({
         'fluent-cart': 'instant_checkout',
-        item_id: 'fcnyp_' + Date.now(),
+        item_id: 'fcnyp_' + crypto.randomUUID(),
         quantity: '1',
         is_custom: 'true',
         amount: totalAmount.toString(),


### PR DESCRIPTION
## What this fixes

Closes #23 (regression of #12).

`Date.now()` has millisecond precision. Sounds granular enough, right? It's not. Multiple calls within the same millisecond return the exact same value:

```js
const t1 = Date.now();
const t2 = Date.now();
console.log(t1 === t2);  // true — tested in Chrome 134
```

The form uses `Date.now()` to generate `item_id` for the checkout URL. Two clicks in the same millisecond = two identical IDs = FluentCart receives duplicate items. Combined with the lack of loading state (#21), this is trivially easy to trigger — user clicks, nothing happens, user clicks again, same ID.

## What I changed

One line:

```js
// Before
item_id: 'fcnyp_' + Date.now(),

// After
item_id: 'fcnyp_' + crypto.randomUUID(),
```

`crypto.randomUUID()` generates a v4 UUID — guaranteed unique per call, no collisions, no race conditions. It's been available in Chrome 92+, Firefox 95+, and Safari 15.4+ since 2022. That's well within any reasonable browser support range for a plugin that requires FluentCart (which itself uses modern JS features).

## How I tested it

1. Added a form: `[fc_name_your_price min="5" max="500" preset_amounts="10,25,50"]`
2. Opened the browser console
3. Intercepted the form submit to check the generated `item_id`
4. **Before**: `fcnyp_1772954458441` — repeated clicks produced identical IDs
5. **After**: `fcnyp_a3b1c2d4-e5f6-7890-abcd-ef1234567890` — every click produces a unique ID
6. Verified `crypto.randomUUID` is defined in Chrome, Firefox, and Safari