### PR TITLE
Validate charged amount against base and max limits

### DIFF
--- a/includes/class-fluentcart-integration.php
+++ b/includes/class-fluentcart-integration.php
@@ -103,6 +103,24 @@ class FluentCartIntegration
             );
         }
 
+        // The charged amount must not be less than what the visitor chose
+        // and must stay within a reasonable fee margin above the base.
+        if ($amount < $baseAmount) {
+            return new \WP_Error(
+                'fcnyp_invalid_amount',
+                __('Invalid amount.', 'fc-name-your-price')
+            );
+        }
+
+        $maxWithFees = $max * 1.15;
+        if ($amount > $maxWithFees) {
+            return new \WP_Error(
+                'fcnyp_amount_too_high',
+                /* translators: %s: formatted maximum amount */
+                sprintf(__('Maximum amount is %s.', 'fc-name-your-price'), self::formatPrice($max))
+            );
+        }
+
         $priceInCents = round($amount * 100);
 
         $productTitle = apply_filters('fcnyp_product_title', $productTitle);

--- a/includes/class-fluentcart-integration.php
+++ b/includes/class-fluentcart-integration.php
@@ -103,9 +103,9 @@ class FluentCartIntegration
             );
         }
 
-        // The charged amount must not be less than what the visitor chose
-        // and must stay within a reasonable fee margin above the base.
-        if ($amount < $baseAmount) {
+        // The charged amount must be positive, not less than the visitor's
+        // choice, and within a reasonable fee margin above the base.
+        if ($amount <= 0 || $amount < $baseAmount) {
             return new \WP_Error(
                 'fcnyp_invalid_amount',
                 __('Invalid amount.', 'fc-name-your-price')


### PR DESCRIPTION
## What this fixes

Closes #28.

This is the scariest one. The server validates `$baseAmount` against the signed min/max limits — that part works. But `$amount`, the value that actually gets converted to cents and charged to the visitor, is a completely separate URL parameter that was **never validated**.

The split exists because of the cover-fees feature (#3): `base_amount` is what the visitor chose, `amount` includes the optional transaction fee. The idea was to validate the base (what they picked) and charge the total (base + fee). Makes sense — until you realise anyone can set these two parameters independently.

### Underpayment (pay nothing on a $5 minimum form)

```
amount=0.01&base_amount=5
```

Server sees `base_amount=5` → passes the min=5 check. Charges `amount=0.01` → rounds to €0.00 on checkout.

### Overcharge (phishing link with real domain + real HMAC)

```
amount=10000&base_amount=5
```

Server sees `base_amount=5` → passes the max=500 check. Charges 10,000 PLN → **€2,332.36** on checkout. The link uses the store's real domain, real product title, real HMAC. Looks completely legitimate.

## What I changed

Two validation checks after the existing `$baseAmount` validation:

```php
// The charged amount must not be less than what the visitor chose
if ($amount < $baseAmount) {
    return new \WP_Error('fcnyp_invalid_amount', __('Invalid amount.', 'fc-name-your-price'));
}

// The charged amount must stay within a reasonable fee margin above max
$maxWithFees = $max * 1.15;
if ($amount > $maxWithFees) {
    return new \WP_Error('fcnyp_amount_too_high', ...);
}
```

**`$amount < $baseAmount`**: Fees can only *add* to the base, never subtract. If the charged amount is less than what the visitor chose, something's been tampered with.

**`$amount > $max * 1.15`**: The 15% multiplier gives generous headroom for the cover-fees feature. A 2.9% + $0.30 fee on a $500 max would be ~$15.80 — well within 15%. But `amount=10000` on a max=500 form gets rightfully rejected.

## How I tested it

1. **Underpayment**: `amount=0.01&base_amount=5` with valid HMAC → **Before**: checkout at €0.00. **After**: rejected with "Invalid amount"
2. **Overcharge**: `amount=10000&base_amount=5` with valid HMAC → **Before**: checkout at €2,332.36. **After**: rejected with "Maximum amount" error
3. **Normal checkout**: `amount=25&base_amount=25` → still works
4. **Cover fees**: `amount=25.93&base_amount=25` (2.9% + 0.30) → still works, within 15% of base