### PR TITLE
Force subscription when mode is required

### DIFF
--- a/includes/class-fluentcart-integration.php
+++ b/includes/class-fluentcart-integration.php
@@ -117,6 +117,10 @@ class FluentCartIntegration
             $paymentType = 'onetime';
         }
 
+        if ($subscriptionMode === 'required') {
+            $paymentType = 'subscription';
+        }
+
         $otherInfo = ['payment_type' => $paymentType];
 
         if ($paymentType === 'subscription') {


### PR DESCRIPTION
## What this fixes

Closes #29.

The fix for #18 added a guard that prevents upgrading a one-time form to a subscription — if `subscription_mode=off`, the server forces `payment_type=onetime`. That works.

But the reverse direction was missed. A form with `subscription_mode=required` can be downgraded to a one-time payment by simply changing `payment_type=onetime` in the URL.

The subscription_mode is HMAC-signed, so the visitor can't change *that*. But `payment_type` is a plain URL parameter they can edit freely. The server reads the signed mode, verifies the HMAC, confirms it says "required" — and then completely ignores that when accepting `payment_type=onetime`.

## Proof

1. Form at `/nyp-sub-required/` with `subscription_mode="required"`
2. Grabbed the valid nonce + HMAC signature
3. Sent checkout URL with `payment_type=onetime` and `fcnyp_subscription_mode=required`
4. Result: Checkout loaded as a one-time payment — €1.17, no recurring indicators, "Place Order" instead of "Subscribe"

The store owner configured this as *required* recurring. The visitor just opted out with a URL edit.

## What I changed

One conditional, mirroring the existing guard:

```php
if ($subscriptionMode === 'required') {
    $paymentType = 'subscription';
}
```

If the signed config says required, force subscription. Full stop. Doesn't matter what `payment_type` the URL says.

Now both directions are covered:
- `off` + visitor sends `subscription` → forced to `onetime` (existing guard)
- `required` + visitor sends `onetime` → forced to `subscription` (new guard)
- `optional` → visitor's choice respected (no change)

## How I tested it

1. Form with `subscription_mode=required`, sent `payment_type=onetime`
2. **Before**: Checkout shows one-time payment
3. **After**: Checkout shows subscription (per month, until cancel)
4. Form with `subscription_mode=off` still correctly blocks subscription attempts
5. Form with `subscription_mode=optional` still respects visitor choice